### PR TITLE
Remove arm build, Bitwarden CLI doesnt support ARM linux yet :( 

### DIFF
--- a/.github/workflows/docker-push-daily.yml
+++ b/.github/workflows/docker-push-daily.yml
@@ -49,7 +49,6 @@ jobs:
           context: docker
           platforms: |
             linux/amd64
-            linux/arm64
           tags: |
             jessebot/bweso:${{ inputs.tag_name }}
 
@@ -63,7 +62,6 @@ jobs:
           context: docker
           platforms: |
             linux/amd64
-            linux/arm64
           tags: |
             jessebot/bweso:${{ github.ref_name }}
 
@@ -80,7 +78,6 @@ jobs:
           context: docker
           platforms: |
             linux/amd64
-            linux/arm64
           tags: |
             jessebot/bweso:nightly
             jessebot/bweso:${{ env.last_tag }}


### PR DESCRIPTION
https://community.bitwarden.com/t/arm-support/8306/27

```shell
[Nov '22]
I suppose the main problem is the MSSQL database server which is not available for ARM:
```

Only has ARM support for macos: https://github.com/bitwarden/clients/releases/download/cli-v2023.7.0/bw-macos-2023.7.0.zip

