### PR TITLE
Convert `cluster-secret-store` url string creation from in-line to `_helpers.tpl`

### DIFF
--- a/.github/workflows/ci-helm-lint-test.yml
+++ b/.github/workflows/ci-helm-lint-test.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Pull and side-load docker container
         run: |
           docker pull --platform=linux/amd64 docker.io/jessebot/bweso:v0.2.0 && \
-          kind load docker-image docker.io/jessebot/bweso:v0.2.0 --name kind
+          kind load docker-image docker.io/jessebot/bweso:v0.2.0 --name kind-chart-testing
         shell: bash
 
       - name: Run chart-testing (install)

--- a/charts/bitwarden-eso-provider/Chart.yaml
+++ b/charts/bitwarden-eso-provider/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.1
+version: 0.4.0
 
 # renovate: image=jessebot/bweso
 appVersion: "v0.2.0"

--- a/charts/bitwarden-eso-provider/README.md
+++ b/charts/bitwarden-eso-provider/README.md
@@ -1,6 +1,6 @@
 # bitwarden-eso-provider
 
-![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.2.0](https://img.shields.io/badge/AppVersion-v0.2.0-informational?style=flat-square)
+![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.2.0](https://img.shields.io/badge/AppVersion-v0.2.0-informational?style=flat-square)
 
 Helm chart to use Bitwarden as a Provider for External Secrets Operator
 
@@ -44,7 +44,7 @@ Helm chart to use Bitwarden as a Provider for External Secrets Operator
 | replicaCount | int | `1` | replicas to deploy of this pod |
 | resources | object | `{}` |  |
 | securityContext | object | `{}` |  |
-| service.port | int | `80` | port to broadcast for k8s service internally on the cluster |
+| service.port | int | `8087` | port to broadcast for k8s service internally on the cluster |
 | service.targetPort | int | `8087` | port on the container to target for the k8s service |
 | service.type | string | `"ClusterIP"` |  |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |

--- a/charts/bitwarden-eso-provider/templates/_helpers.tpl
+++ b/charts/bitwarden-eso-provider/templates/_helpers.tpl
@@ -75,5 +75,5 @@ Create the url string that will be used to query bitwarden
 - cluster-secret-store items jsonpath
 */}}
 {{- define "bitwarden-eso-provider.clusterSecretStore.loginJsonPath" -}}
-{{- printf "$.data.data.[0].{{ remoteRef.property }}" | quote }}
+{{- printf "$.data.data[0].login.{{ remoteRef.property }}" | quote }}
 {{- end }}

--- a/charts/bitwarden-eso-provider/templates/_helpers.tpl
+++ b/charts/bitwarden-eso-provider/templates/_helpers.tpl
@@ -66,7 +66,7 @@ Create the url string that will be used to query Bitwarden:
 - cluster-secret-store login url
 */}}
 {{- define "bitwarden-eso-provider.clusterSecretStore.loginUrl" -}}
-{{- printf "http://%s.%s.svc.cluster.local:%s/list/object/items?search={{ remoteRef.key }}" .Release.Name .Release.Namespace (.Values.service.port | toString) }}
+{{- printf "http://%s.%s.svc.cluster.local:%s/list/object/items?search={{ remoteRef.key }}" .Release.Name .Release.Namespace (.Values.service.port | toString) | quote }}
 {{- end }}
 
 
@@ -75,5 +75,5 @@ Create the url string that will be used to query bitwarden
 - cluster-secret-store items jsonpath
 */}}
 {{- define "bitwarden-eso-provider.clusterSecretStore.loginJsonPath" -}}
-{{- printf "$.data.data.[0].{{ remoteRef.property }}" }}
+{{- printf "$.data.data.[0].{{ remoteRef.property }}" | quote }}
 {{- end }}

--- a/charts/bitwarden-eso-provider/templates/_helpers.tpl
+++ b/charts/bitwarden-eso-provider/templates/_helpers.tpl
@@ -60,3 +60,10 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create the url string that will be used to query Bitwarden for secrets
+*/}}
+{{- define "bitwarden-eso-provider.clusterSecretStore.loginUrl" -}}
+{{- printf "http://%s.%s.svc.cluster.local:%s/list/object/items?search={{ remoteRef.key }}" .Release.Name .Release.Namespace (.Values.service.port | toString) }}
+{{- end }}

--- a/charts/bitwarden-eso-provider/templates/_helpers.tpl
+++ b/charts/bitwarden-eso-provider/templates/_helpers.tpl
@@ -93,5 +93,5 @@ Create the url string that will be used to query bitwarden
 - cluster-secret-store fields jsonpath
 */}}
 {{- define "bitwarden-eso-provider.clusterSecretStore.fieldsJsonPath" -}}
-{{- printf "$.data.data[0].fields[?(@.name=='{{ .remoteRef.property }}')].value" | quote }}
+{{- printf "$.data.data[0].fields[?(@.name==\"{{ .remoteRef.property }}\")].value" | quote }}
 {{- end }}

--- a/charts/bitwarden-eso-provider/templates/_helpers.tpl
+++ b/charts/bitwarden-eso-provider/templates/_helpers.tpl
@@ -62,8 +62,18 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
-Create the url string that will be used to query Bitwarden for secrets
+Create the url string that will be used to query Bitwarden:
+- cluster-secret-store login url
 */}}
 {{- define "bitwarden-eso-provider.clusterSecretStore.loginUrl" -}}
 {{- printf "http://%s.%s.svc.cluster.local:%s/list/object/items?search={{ remoteRef.key }}" .Release.Name .Release.Namespace (.Values.service.port | toString) }}
+{{- end }}
+
+
+{{/*
+Create the url string that will be used to query bitwarden
+- cluster-secret-store items jsonpath
+*/}}
+{{- define "bitwarden-eso-provider.clusterSecretStore.loginJsonPath" -}}
+{{- printf "$.data.data.[0].{{ remoteRef.property }}" }}
 {{- end }}

--- a/charts/bitwarden-eso-provider/templates/_helpers.tpl
+++ b/charts/bitwarden-eso-provider/templates/_helpers.tpl
@@ -63,7 +63,7 @@ Create the name of the service account to use
 
 {{/*
 Create the url string that will be used to query Bitwarden:
-- cluster-secret-store login url
+- cluster-secret-store logins url
 */}}
 {{- define "bitwarden-eso-provider.clusterSecretStore.loginUrl" -}}
 {{- printf "http://%s.%s.svc.cluster.local:%s/list/object/items?search={{ .remoteRef.key }}" .Release.Name .Release.Namespace (.Values.service.port | toString) | quote }}
@@ -72,8 +72,26 @@ Create the url string that will be used to query Bitwarden:
 
 {{/*
 Create the url string that will be used to query bitwarden
-- cluster-secret-store items jsonpath
+- cluster-secret-store logins jsonpath
 */}}
 {{- define "bitwarden-eso-provider.clusterSecretStore.loginJsonPath" -}}
 {{- printf "$.data.data[0].login.{{ .remoteRef.property }}" | quote }}
+{{- end }}
+
+
+{{/*
+Create the url string that will be used to query Bitwarden:
+- cluster-secret-store fields url
+*/}}
+{{- define "bitwarden-eso-provider.clusterSecretStore.fieldsUrl" -}}
+{{- printf "http://%s.%s.svc.cluster.local:%s/list/object/items?search={{ .remoteRef.key }}" .Release.Name .Release.Namespace (.Values.service.port | toString) | quote }}
+{{- end }}
+
+
+{{/*
+Create the url string that will be used to query bitwarden
+- cluster-secret-store fields jsonpath
+*/}}
+{{- define "bitwarden-eso-provider.clusterSecretStore.fieldsJsonPath" -}}
+{{- printf "$.data.data[0].fields[?(@.name=='{{ .remoteRef.property }}')].value" | quote }}
 {{- end }}

--- a/charts/bitwarden-eso-provider/templates/_helpers.tpl
+++ b/charts/bitwarden-eso-provider/templates/_helpers.tpl
@@ -66,7 +66,7 @@ Create the url string that will be used to query Bitwarden:
 - cluster-secret-store login url
 */}}
 {{- define "bitwarden-eso-provider.clusterSecretStore.loginUrl" -}}
-{{- printf "http://%s.%s.svc.cluster.local:%s/list/object/items?search={{ remoteRef.key }}" .Release.Name .Release.Namespace (.Values.service.port | toString) | quote }}
+{{- printf "http://%s.%s.svc.cluster.local:%s/list/object/items?search={{ .remoteRef.key }}" .Release.Name .Release.Namespace (.Values.service.port | toString) | quote }}
 {{- end }}
 
 
@@ -75,5 +75,5 @@ Create the url string that will be used to query bitwarden
 - cluster-secret-store items jsonpath
 */}}
 {{- define "bitwarden-eso-provider.clusterSecretStore.loginJsonPath" -}}
-{{- printf "$.data.data[0].login.{{ remoteRef.property }}" | quote }}
+{{- printf "$.data.data[0].login.{{ .remoteRef.property }}" | quote }}
 {{- end }}

--- a/charts/bitwarden-eso-provider/templates/cluster-secret-stores.yaml
+++ b/charts/bitwarden-eso-provider/templates/cluster-secret-stores.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   provider:
     webhook:
-      url: "http://{{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}/list/object/items"
+      url: {{ include "bitwarden-eso-provider.clusterSecretStore.loginUrl" . }}
       headers:
         Content-Type: application/json
       result:

--- a/charts/bitwarden-eso-provider/templates/cluster-secret-stores.yaml
+++ b/charts/bitwarden-eso-provider/templates/cluster-secret-stores.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   provider:
     webhook:
-      url: "http://{{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}/list/object/items"
+      url: {{ include "bitwarden-eso-provider.clusterSecretStore.fieldsUrl" . }}
       result:
-        jsonPath: "$.data.data[?(@.name==\"{{`{{ .remoteRef.key }}`}}\"].fields[?@.name==\"{{`{{ .remoteRef.property }}`}}\"].value"
+        jsonPath: {{ include "bitwarden-eso-provider.clusterSecretStore.fieldsJsonPath" . }}
 {{- end }}

--- a/charts/bitwarden-eso-provider/templates/cluster-secret-stores.yaml
+++ b/charts/bitwarden-eso-provider/templates/cluster-secret-stores.yaml
@@ -7,11 +7,11 @@ metadata:
 spec:
   provider:
     webhook:
-      url: "http://{{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}/object/items"
+      url: "http://{{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}/list/object/items"
       headers:
         Content-Type: application/json
       result:
-        jsonPath: "$.data.data[?(@.name=={{`{{ .remoteRef.key }}`}})].login.{{`{{ .remoteRef.property }}`}}"
+        jsonPath: '{{ `$.data.data[?(@.name=={{ .remoteRef.key }})].login.{{ .remoteRef.property }}` }}'
 ---
 apiVersion: external-secrets.io/v1beta1
 kind: ClusterSecretStore
@@ -20,7 +20,7 @@ metadata:
 spec:
   provider:
     webhook:
-      url: "http://{{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}/object/item/"
+      url: "http://{{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}/list/object/items"
       result:
         jsonPath: "$.data.data[?(@.name==\"{{`{{ .remoteRef.key }}`}}\"].fields[?@.name==\"{{`{{ .remoteRef.property }}`}}\"].value"
 {{- end }}

--- a/charts/bitwarden-eso-provider/templates/cluster-secret-stores.yaml
+++ b/charts/bitwarden-eso-provider/templates/cluster-secret-stores.yaml
@@ -11,7 +11,7 @@ spec:
       headers:
         Content-Type: application/json
       result:
-        jsonPath: '{{ `$.data.data[?(@.name=={{ .remoteRef.key }})].login.{{ .remoteRef.property }}` }}'
+        jsonPath: {{ include "bitwarden-eso-provider.clusterSecretStore.loginJsonPath" . }}
 ---
 apiVersion: external-secrets.io/v1beta1
 kind: ClusterSecretStore

--- a/charts/bitwarden-eso-provider/templates/credentials.yaml
+++ b/charts/bitwarden-eso-provider/templates/credentials.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
 type: Opaque
 data:
   BW_HOST: {{ .Values.bitwarden_eso_provider.auth.host | b64enc | quote }}

--- a/charts/bitwarden-eso-provider/templates/deployment.yaml
+++ b/charts/bitwarden-eso-provider/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "bitwarden-eso-provider.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "bitwarden-eso-provider.labels" . | nindent 4 }}
 spec:
@@ -63,18 +64,18 @@ spec:
               command:
                 - wget
                 - -q
-                - http://127.0.0.1:{{ .Values.service.targetPort }}/sync
+                - http://127.0.0.1:{{ .Values.service.port }}/sync
                 - --post-data=''
           readinessProbe:
             tcpSocket:
-              port: {{ .Values.service.targetPort }}
+              port: {{ .Values.service.port }}
             initialDelaySeconds: 20
             failureThreshold: 3
             timeoutSeconds: 1
             periodSeconds: 10
           startupProbe:
             tcpSocket:
-              port: {{ .Values.service.targetPort }}
+              port: {{ .Values.service.port }}
             initialDelaySeconds: 10
             failureThreshold: 30
             timeoutSeconds: 1

--- a/charts/bitwarden-eso-provider/templates/hpa.yaml
+++ b/charts/bitwarden-eso-provider/templates/hpa.yaml
@@ -3,6 +3,7 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "bitwarden-eso-provider.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "bitwarden-eso-provider.labels" . | nindent 4 }}
 spec:

--- a/charts/bitwarden-eso-provider/templates/network-policy.yaml
+++ b/charts/bitwarden-eso-provider/templates/network-policy.yaml
@@ -4,6 +4,7 @@ kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
   name: external-secret-2-{{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
 spec:
   podSelector:
     matchLabels:

--- a/charts/bitwarden-eso-provider/templates/service.yaml
+++ b/charts/bitwarden-eso-provider/templates/service.yaml
@@ -1,7 +1,8 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "bitwarden-eso-provider.fullname" . }}
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "bitwarden-eso-provider.labels" . | nindent 4 }}
 spec:

--- a/charts/bitwarden-eso-provider/templates/tests/test-configmap.yaml
+++ b/charts/bitwarden-eso-provider/templates/tests/test-configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: test-connection
+  namespace: {{ .Release.Namespace }}
 data:
   curl_script.sh: |
-    curl http://{{ include "bitwarden-eso-provider.fullname" . }}:{{ .Values.service.port }}/status
+    curl http://{{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}/status

--- a/charts/bitwarden-eso-provider/templates/tests/test-connection.yaml
+++ b/charts/bitwarden-eso-provider/templates/tests/test-connection.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: "{{ include "bitwarden-eso-provider.fullname" . }}-test-connection"
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "bitwarden-eso-provider.labels" . | nindent 4 }}
   annotations:
@@ -23,4 +24,4 @@ spec:
       configMap:
         name: test-connection
         defaultMode: 0777
-  restartPolicy: Never
+  restartPolicy: Always

--- a/charts/bitwarden-eso-provider/templates/tests/test-connection.yaml
+++ b/charts/bitwarden-eso-provider/templates/tests/test-connection.yaml
@@ -24,4 +24,4 @@ spec:
       configMap:
         name: test-connection
         defaultMode: 0777
-  restartPolicy: Always
+  restartPolicy: OnFailure

--- a/charts/bitwarden-eso-provider/values.yaml
+++ b/charts/bitwarden-eso-provider/values.yaml
@@ -32,7 +32,7 @@ bitwarden_eso_provider:
     # -- bitwarden hostname to use to grab secrets in the pod, ignored if existingSecret is set
     host: "https://bitwarden.com"
     # -- use an existing secret for bitwarden credentials, ignores above credentials if this is set
-    existingSecret: ""
+    existingSecret: "bitwarden"
     secretKeys:
       # -- secret key for bitwarden password key
       password: "BW_PASSWORD"
@@ -71,7 +71,7 @@ service:
   # -- port on the container to target for the k8s service
   targetPort: 8087
   # -- port to broadcast for k8s service internally on the cluster
-  port: 80
+  port: 8087
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/bitwarden-eso-provider/values.yaml
+++ b/charts/bitwarden-eso-provider/values.yaml
@@ -32,7 +32,7 @@ bitwarden_eso_provider:
     # -- bitwarden hostname to use to grab secrets in the pod, ignored if existingSecret is set
     host: "https://bitwarden.com"
     # -- use an existing secret for bitwarden credentials, ignores above credentials if this is set
-    existingSecret: "bitwarden"
+    existingSecret: ""
     secretKeys:
       # -- secret key for bitwarden password key
       password: "BW_PASSWORD"


### PR DESCRIPTION
This PR makes some tweaks to get BWESO working with helm.

Most natably, we needed to move the cluster-secret-store `URL` and `JSONpath` string construction into `_helpers.tpl` because of the issues that popped up trying to put a string-literal into the helm template.