### PR TITLE
Configure sync rate and default probes for bweso 

### DIFF
--- a/charts/bitwarden-eso-provider/Chart.yaml
+++ b/charts/bitwarden-eso-provider/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.4.1
 
 # renovate: image=jessebot/bweso
 appVersion: "v0.2.0"

--- a/charts/bitwarden-eso-provider/README.md
+++ b/charts/bitwarden-eso-provider/README.md
@@ -1,6 +1,6 @@
 # bitwarden-eso-provider
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.2.0](https://img.shields.io/badge/AppVersion-v0.2.0-informational?style=flat-square)
+![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.2.0](https://img.shields.io/badge/AppVersion-v0.2.0-informational?style=flat-square)
 
 Helm chart to use Bitwarden as a Provider for External Secrets Operator
 
@@ -35,12 +35,18 @@ Helm chart to use Bitwarden as a Provider for External Secrets Operator
 | image.repository | string | `"jessebot/bweso"` | Overrides the image repository |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` |  |
+| livenessProbe | object | `{"failureThreshold":30,"initialDelaySeconds":20,"periodSeconds":10,"timeoutSeconds":1}` | The livenessProbe calls the `bw sync` command. |
+| livenessProbe.periodSeconds | int | `10` | The `periodSeconds` value controls how long to wait until next `bw sync` |
 | nameOverride | string | `""` | this overrides the name of the chart |
 | network_policy.enabled | bool | `true` | enable a network policy between bitwarden_eso_provider and external-secrets-operator |
 | network_policy.labels | object | `{"app.kubernetes.io/name":"external-secrets"}` | specify the labels you'd like to match against for the network policy |
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` | additional annotations to apply to the bitwarden ESO provider pod |
 | podSecurityContext | object | `{}` |  |
+| readinessProbe.failureThreshold | int | `30` |  |
+| readinessProbe.initialDelaySeconds | int | `20` |  |
+| readinessProbe.periodSeconds | int | `10` |  |
+| readinessProbe.timeoutSeconds | int | `1` |  |
 | replicaCount | int | `1` | replicas to deploy of this pod |
 | resources | object | `{}` |  |
 | securityContext | object | `{}` |  |
@@ -50,6 +56,10 @@ Helm chart to use Bitwarden as a Provider for External Secrets Operator
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
+| startupProbe.failureThreshold | int | `30` |  |
+| startupProbe.initialDelaySeconds | int | `20` |  |
+| startupProbe.periodSeconds | int | `10` |  |
+| startupProbe.timeoutSeconds | int | `1` |  |
 | tolerations | list | `[]` |  |
 
 ----------------------------------------------

--- a/charts/bitwarden-eso-provider/templates/deployment.yaml
+++ b/charts/bitwarden-eso-provider/templates/deployment.yaml
@@ -66,24 +66,24 @@ spec:
                 - -q
                 - http://127.0.0.1:{{ .Values.service.port }}/sync
                 - --post-data=''
-            initialDelaySeconds: 20
-            failureThreshold: 30
-            timeoutSeconds: 1
-            periodSeconds: 10
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
           readinessProbe:
             tcpSocket:
               port: {{ .Values.service.port }}
-            initialDelaySeconds: 20
-            failureThreshold: 3
-            timeoutSeconds: 1
-            periodSeconds: 10
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
           startupProbe:
             tcpSocket:
               port: {{ .Values.service.port }}
-            initialDelaySeconds: 10
-            failureThreshold: 30
-            timeoutSeconds: 1
-            periodSeconds: 5
+            initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/charts/bitwarden-eso-provider/templates/deployment.yaml
+++ b/charts/bitwarden-eso-provider/templates/deployment.yaml
@@ -66,6 +66,10 @@ spec:
                 - -q
                 - http://127.0.0.1:{{ .Values.service.port }}/sync
                 - --post-data=''
+            initialDelaySeconds: 20
+            failureThreshold: 30
+            timeoutSeconds: 1
+            periodSeconds: 10
           readinessProbe:
             tcpSocket:
               port: {{ .Values.service.port }}

--- a/charts/bitwarden-eso-provider/values.yaml
+++ b/charts/bitwarden-eso-provider/values.yaml
@@ -127,5 +127,3 @@ startupProbe:
   failureThreshold: 30
   timeoutSeconds: 1
   periodSeconds: 10
-
-

--- a/charts/bitwarden-eso-provider/values.yaml
+++ b/charts/bitwarden-eso-provider/values.yaml
@@ -107,3 +107,25 @@ network_policy:
   # -- specify the labels you'd like to match against for the network policy
   labels:
     app.kubernetes.io/name: external-secrets
+
+# -- The livenessProbe calls the `bw sync` command.
+livenessProbe:
+  initialDelaySeconds: 20
+  failureThreshold: 30
+  timeoutSeconds: 1
+  # -- The `periodSeconds` value controls how long to wait until next `bw sync`
+  periodSeconds: 10
+
+readinessProbe:
+  initialDelaySeconds: 20
+  failureThreshold: 30
+  timeoutSeconds: 1
+  periodSeconds: 10
+
+startupProbe:
+  initialDelaySeconds: 20
+  failureThreshold: 30
+  timeoutSeconds: 1
+  periodSeconds: 10
+
+


### PR DESCRIPTION
adds options to the liveness probe which will let us set the sync delay explicitly